### PR TITLE
Add dswizard and XAutoML to component overview

### DIFF
--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -10,3 +10,9 @@ Eclipse BaSyx is a open source Industry 4.0 middleware that realizes  all necess
 
 ## [Service Lifecycle Management](https://slm.docs.fab-os.org/docs/getting-started/)
 The Service Lifecycle Management forms the backbone for providing and executing software services in FabOS. With the asset administration shell, an open standard is used to describe system resources and software services. At the same time, it enables distributed execution and the utilization of available system resources in FabOS. It thus supports the use of the production services developed in FabOS and their execution in a production environment.
+
+## [dswizard](https://github.com/FabOS-AI/fabos-base-service-dswizard)
+The creation of sophisticated, high-perfoming data anlysis usually requires an intradisciplinary team of domain experts, programmers and data scientist. Automated machine learning (AutoML) aims to enable domain experts to build state-of-the-art data anlysis on their own. dswizard is an efficient solver for ML pipeline synthesis inspired by human behaviour. It automatically derives a pipeline structure, selects algorithms and performs hyperparameter optimization.
+
+## [XAutoML](https://github.com/FabOS-AI/fabos-base-service-xautoml)
+XAutoML (for *eXplainable AUTOmated Machine Learning*) is an interactive visual analytics tool for explaining AutoML optimisation procedures and ML pipelines constructed by AutoML. It combines interactive visualizations with established techniques from explainable AI (XAI) to make the complete AutoML procedure transparent and explainable.


### PR DESCRIPTION
I have added dswizard and XAutoML to the component overview and linked both components to the according FabOS-AI repos. Is there any other place where I should add documentation?